### PR TITLE
aroo

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -36327,8 +36327,8 @@ function getOctokit(token, options, ...additionalPlugins) {
     DEBUG && core_debug(`TARGET_IGNORE_REPOS: ${TARGET_IGNORE_REPOS}`)
     DEBUG && core_debug(`DAYS_THRESHOLD: ${DAYS_THRESHOLD}`)
 
-    const sevenDaysAgo = new Date()
-    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - parseInt(DAYS_THRESHOLD))
+    const cutoffDate = new Date()
+    cutoffDate.setDate(cutoffDate.getDate() - parseInt(DAYS_THRESHOLD))
     let errorOccurred = false
 
     // GitHub API client setup
@@ -36398,42 +36398,37 @@ function getOctokit(token, options, ...additionalPlugins) {
     for(const repo of reposArray) {
       info(`Processing repository: ${repo}`)
 
+      const [ownerName, repoName] = repo.split("/")
+
       const {actions} = octokit.rest
+
+      // First, page through every workflow run and collect the ones older
+      // than the threshold. We must gather the full list before deleting,
+      // because deleting during pagination shifts later runs onto earlier
+      // pages, and because a page of recent runs is not a signal that no
+      // older runs remain (runs are returned newest-first, so older runs
+      // live on later pages).
+      const runsToDelete = []
       let runPage = 1
+      let fetchFailed = false
       while(true) {
         try {
           const runsResponse = await actions.listWorkflowRunsForRepo({
-            owner: repo.split("/")[0],
-            repo: repo.split("/")[1],
+            owner: ownerName,
+            repo: repoName,
             per_page: 100,
             page: runPage
           })
 
-          const runs = runsResponse.data.workflow_runs.filter(run => {
-            return new Date(run.created_at) < sevenDaysAgo
-          })
+          const pageRuns = runsResponse.data.workflow_runs
 
-          if(runs.length === 0) {
-            info(`No more runs to process in repository: ${repo}.`)
+          if(pageRuns.length === 0) {
             break
           }
 
-          for(const run of runs) {
-            const runId = run.id
-            info(`Deleting workflow run ${runId} in repository ${repo}`)
-
-            try {
-              await actions.deleteWorkflowRun({
-                owner: repo.split("/")[0],
-                repo: repo.split("/")[1],
-                run_id: runId
-              })
-              info(`Successfully deleted run ${runId}.`)
-              result.wfRuns += 1
-            } catch(deleteError) {
-              error(`Failed to delete run ${runId}. Response: ${deleteError.message}`)
-              result.errors += 1
-              errorOccurred = true
+          for(const run of pageRuns) {
+            if(new Date(run.created_at) < cutoffDate) {
+              runsToDelete.push(run)
             }
           }
 
@@ -36441,7 +36436,34 @@ function getOctokit(token, options, ...additionalPlugins) {
         } catch(runsError) {
           error(`Failed to fetch runs for repository ${repo}. Response: ${runsError.message}`)
           errorOccurred = true
+          fetchFailed = true
           break
+        }
+      }
+
+      if(fetchFailed) {
+        continue
+      }
+
+      info(`Found ${runsToDelete.length} workflow run(s) to delete in repository ${repo}.`)
+
+      // Now delete the collected runs.
+      for(const run of runsToDelete) {
+        const runId = run.id
+        info(`Deleting workflow run ${runId} in repository ${repo}`)
+
+        try {
+          await actions.deleteWorkflowRun({
+            owner: ownerName,
+            repo: repoName,
+            run_id: runId
+          })
+          info(`Successfully deleted run ${runId}.`)
+          result.wfRuns += 1
+        } catch(deleteError) {
+          error(`Failed to delete run ${runId}. Response: ${deleteError.message}`)
+          result.errors += 1
+          errorOccurred = true
         }
       }
     }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the workflow run deletion logic from a single-phase (paginate-and-delete) to a two-phase (collect-then-delete) approach, fixing two real bugs in the original implementation.

- **Pagination bug fixed**: The old code stopped iterating pages as soon as a filtered-by-date page returned zero results. Because GitHub returns runs newest-first, page 1 would almost always be all-recent runs, making the old code break immediately and never find older runs on later pages.
- **Deletion-during-pagination bug fixed**: The old code deleted runs while paginating, which causes page offsets to shift and runs to be silently skipped. The new approach collects all eligible run IDs first, then deletes them in a separate pass.
- Also includes a clean rename of `sevenDaysAgo` → `cutoffDate` (since the threshold is configurable) and a one-time destructure of `ownerName`/`repoName` instead of repeated `split("/")` calls.

<h3>Confidence Score: 5/5</h3>

The change is a targeted correctness fix with no regressions; the two-phase collect-then-delete pattern is strictly more correct than the original.

Both root causes are well-understood and the new logic correctly addresses them. The fetchFailed guard, the runPage increment, and the runsToDelete accumulator all work as expected. No pre-existing logic was removed that would leave a gap.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["aroo"](https://github.com/gesslar/workflow-run-cleaner/commit/333a00529bd367d3ced529ef098db659736d5bc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37507997)</sub>

<!-- /greptile_comment -->