### PR TITLE
updating

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,13 +19,6 @@ inputs:
     description: 'Number of days to keep workflow runs'
     required: false
     default: '7'
-  notification-webhook-type:
-    description: 'Type of notification webhook'
-    required: false
-    default: 'discord'
-  notification-webhook-url:
-    description: 'Webhook URL for sending notifications'
-    required: false
   debug:
     description: 'Enable debug mode'
     required: false


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes two optional action inputs — `notification-webhook-type` and `notification-webhook-url` — from `action.yml`. The compiled `dist/index.js` contains no references to either input, confirming they were never exercised by the action runtime.

- Removed `notification-webhook-type` (defaulted to `'discord'`) and `notification-webhook-url` inputs from the action's input schema.
- No other files reference these inputs, so the removal is complete and self-consistent.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes two declared-but-unused action inputs with no code referencing them.

The deleted inputs (notification-webhook-type, notification-webhook-url) have no corresponding usage in dist/index.js or any other file in the repository. The removal is complete and consistent.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["empty"](https://github.com/gesslar/workflow-run-cleaner/commit/627166588b3ae5922497c573928970ab770d809b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37509937)</sub>

<!-- /greptile_comment -->